### PR TITLE
Added template tag for profile image

### DIFF
--- a/la_facebook/models.py
+++ b/la_facebook/models.py
@@ -14,3 +14,12 @@ class UserAssociation(models.Model):
     
     def expired(self):
         return datetime.datetime.now() < self.expires
+    
+    @property
+    def clean_identifier(self):
+        """
+        Strip fb- out of identifier.
+        
+        Should this be done in the save method? Is there a reason to store fb-?
+        """
+        return self.identifier.replace('fb-', '')

--- a/la_facebook/templatetags/la_facebook_tags.py
+++ b/la_facebook/templatetags/la_facebook_tags.py
@@ -16,7 +16,7 @@ def authed_via(user):
     else:
         return False
     
-@register.filter
+@register.simple_tag
 def profile_pic_src(user, type='normal'):
     """
     Returns url for user's Facebook profile. The url format is:
@@ -31,9 +31,9 @@ def profile_pic_src(user, type='normal'):
         try:
             assoc = UserAssociation.objects.get(user=user)
         except UserAssociation.DoesNotExist:
-            return None
+            return ''
         url = 'http://graph.facebook.com/%s/picture?type=%s'
-        return url % (assoc.identifier, type)
+        return url % (assoc.clean_identifier, type)
     else:
-        return None
+        return ''
     

--- a/la_facebook/templatetags/la_facebook_tags.py
+++ b/la_facebook/templatetags/la_facebook_tags.py
@@ -15,3 +15,25 @@ def authed_via(user):
         return assoc.expired()
     else:
         return False
+    
+@register.filter
+def profile_pic_src(user, type='normal'):
+    """
+    Returns url for user's Facebook profile. The url format is:
+    
+        http://graph.facebook.com/<fb id>/picture?type=<type>
+        
+    Valid type values are: small, normal, large.
+    
+    #TODO: Return empty string instead of none?
+    """
+    if user.is_authenticated():
+        try:
+            assoc = UserAssociation.objects.get(user=user)
+        except UserAssociation.DoesNotExist:
+            return None
+        url = 'http://graph.facebook.com/%s/picture?type=%s'
+        return url % (assoc.identifier, type)
+    else:
+        return None
+    

--- a/la_facebook/templatetags/la_facebook_tags.py
+++ b/la_facebook/templatetags/la_facebook_tags.py
@@ -24,8 +24,6 @@ def profile_pic_src(user, type='normal'):
         http://graph.facebook.com/<fb id>/picture?type=<type>
         
     Valid type values are: small, normal, large.
-    
-    #TODO: Return empty string instead of none?
     """
     if user.is_authenticated():
         try:

--- a/test_project/connect/templates/after.html
+++ b/test_project/connect/templates/after.html
@@ -1,3 +1,5 @@
+{% load la_facebook_tags %}
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -6,6 +8,7 @@
 <body>
     <h2>Login Protected Page</h2>
     {% if user %}
+        <img src="{% profile_pic_src user %}" alt="profile_pic">
         {% if profile %}
             Your name is {{ profile.name }}. You're all about {{ profile.bio }}
         {% else %}


### PR DESCRIPTION
Simple template tag to build src attribute for the user's profile pic.

Usage:

{% load la_facebook_tags %}
<img src="{% profile_pic_src user %}" alt="profile_pic">

A second optional argument can be passed for the size of the image returned. Valid values: small, normal, large. Default is normal.

<img src="{% profile_pic_src user 'small' %}" alt="profile_pic">
