### PR TITLE
Fix crash when the key is not found.

### DIFF
--- a/la_facebook/callbacks/base.py
+++ b/la_facebook/callbacks/base.py
@@ -71,7 +71,7 @@ class BaseFacebookCallback(object):
             logger.debug("redirect not in get params")
             # try the session if available
             if hasattr(request, "session"):
-                redirect_to = request.session.get(session_key_value)
+                redirect_to = request.session.get(session_key_value, "")
                 # Heavier security check -- don't allow redirection to a different host.
                 netloc = urlparse.urlparse(redirect_to)[1]
                 if netloc and netloc != request.host:

--- a/la_facebook/callbacks/base.py
+++ b/la_facebook/callbacks/base.py
@@ -72,6 +72,7 @@ class BaseFacebookCallback(object):
             # try the session if available
             if hasattr(request, "session"):
                 redirect_to = request.session.get(session_key_value, "")
+                if redirect_to is None: redirect_to = ""
                 # Heavier security check -- don't allow redirection to a different host.
                 netloc = urlparse.urlparse(redirect_to)[1]
                 if netloc and netloc != request.host:


### PR DESCRIPTION
If the key is not found, .get() will return None and the program will crash. This way, it doesn't.
